### PR TITLE
Box digestion functions

### DIFF
--- a/molsysmt/_private/digestion/__init__.py
+++ b/molsysmt/_private/digestion/__init__.py
@@ -1,6 +1,5 @@
 from .argument import digest_argument
-from .box import digest_box
-from .box import digest_box_vectors
+from .box import digest_box, digest_box_angles, digest_box_lengths
 from .coordinates import digest_coordinates
 from .comparison import digest_comparison
 from .element import digest_element

--- a/molsysmt/_private/digestion/box.py
+++ b/molsysmt/_private/digestion/box.py
@@ -8,8 +8,8 @@ def digest_box(box):
     return box
 
 
-def digest_box_vectors_value(box_vectors):
-    """ Checks if box_vectors has the correct shape.
+def digest_box_values(box_values):
+    """ Checks if box_values has the correct shape.
 
         The array should have shape (n, 3) where n is any integer.
         However, if a list, tuple is passed it will be converted
@@ -20,7 +20,7 @@ def digest_box_vectors_value(box_vectors):
 
         Parameters
         ----------
-        box_vectors : np.ndarray, list or tuple
+        box_values : np.ndarray, list or tuple
             A quantity with the box lengths.
 
         Raises
@@ -28,14 +28,14 @@ def digest_box_vectors_value(box_vectors):
         IncorrectShapeError
             If box_vectors doesn't have the correct shape.
     """
-    if not(isinstance(box_vectors, np.ndarray)):
-        box_vectors = np.array(box_vectors)
+    if not(isinstance(box_values, np.ndarray)):
+        box_values = np.array(box_values)
 
-    shape = box_vectors.shape
+    shape = box_values.shape
 
     if len(shape) == 1:
         if shape[0] == 3:
-            box_vectors = np.expand_dims(box_vectors, axis=0)
+            box_values = np.expand_dims(box_values, axis=0)
         else:
             raise IncorrectShapeError(expected_shape="(1, 3)", actual_shape=str(shape))
     elif len(shape) == 2:
@@ -44,17 +44,17 @@ def digest_box_vectors_value(box_vectors):
     else:
         raise IncorrectShapeError(expected_shape="(n, 3)", actual_shape=str(shape))
 
-    return box_vectors
+    return box_values
 
 
-def digest_box_vectors(box_vectors):
-    """ Checks if box vectors have the correct shape. Can be used
+def digest_box_lengths_or_angles(box_parameters):
+    """ Checks if box_parameters have the correct shape. Can be used
         to check box_lengths and box_angles.
 
         Parameters
         ----------
-        box_vectors : puw.Quantity
-            A quantity with the box vectors.
+        box_parameters : puw.Quantity
+            A quantity with the box lengths or box values.
 
         Returns
         -------
@@ -66,7 +66,17 @@ def digest_box_vectors(box_vectors):
         IncorrectShapeError
             If box_vectors doesn't have the correct shape.
     """
-    unit = puw.get_unit(box_vectors)
-    box_vectors = puw.get_value(box_vectors)
-    box_vectors = digest_box_vectors_value(box_vectors)
-    return box_vectors * unit
+    unit = puw.get_unit(box_parameters)
+    box_parameters = puw.get_value(box_parameters)
+    box_parameters = digest_box_values(box_parameters)
+    return box_parameters * unit
+
+
+def digest_box_lengths(box_lengths):
+    """ Checks if box_lengths have the correct shape. """
+    return digest_box_lengths_or_angles(box_lengths)
+
+
+def digest_box_angles(box_angles):
+    """ Checks if box_angles have the correct shape. """
+    return digest_box_lengths_or_angles(box_angles)

--- a/molsysmt/pbc/box_vectors_from_box_lengths_and_angles.py
+++ b/molsysmt/pbc/box_vectors_from_box_lengths_and_angles.py
@@ -1,4 +1,4 @@
-from molsysmt._private.digestion import digest_box_vectors
+from molsysmt._private.digestion import digest_box_angles, digest_box_lengths
 from molsysmt.lib import box as libbox
 import numpy as np
 from molsysmt import puw
@@ -6,8 +6,8 @@ from molsysmt import puw
 
 def box_vectors_from_box_lengths_and_angles(lengths, angles):
 
-    lengths = digest_box_vectors(lengths)
-    angles = digest_box_vectors(angles)
+    lengths = digest_box_lengths(lengths)
+    angles = digest_box_angles(angles)
 
     units = puw.get_unit(lengths)
     lengths_value = puw.get_value(lengths)

--- a/molsysmt/tests/digest/test_digest.py
+++ b/molsysmt/tests/digest/test_digest.py
@@ -1,7 +1,7 @@
 # Tests for digestion functions
 from molsysmt._private.exceptions import IncorrectShapeError, WrongEngineError, WrongElementError
 from molsysmt._private.exceptions import WrongFormError, WrongIndicesError
-from molsysmt._private.digestion.box import digest_box_vectors, digest_box_vectors_value
+from molsysmt._private.digestion.box import digest_box_lengths_or_angles, digest_box_values
 from molsysmt._private.digestion import digest_element, digest_engine, digest_form
 from molsysmt._private.digestion import digest_indices
 from molsysmt import puw
@@ -11,40 +11,40 @@ import numpy as np
 
 # Tests for digest box #
 
-def test_digest_box_vectors_value_with_list_and_tuple():
+def test_digest_box_values_with_list_and_tuple():
     lengths_list = [1, 2, 3]
     lengths_expected = np.array([[1, 2, 3]])
-    lengths_digested = digest_box_vectors_value(lengths_list)
+    lengths_digested = digest_box_values(lengths_list)
     assert np.all(lengths_digested == lengths_expected)
 
     lengths_tuple = (1, 2, 3)
-    lengths_digested = digest_box_vectors_value(lengths_tuple)
+    lengths_digested = digest_box_values(lengths_tuple)
     assert np.all(lengths_digested == lengths_expected)
 
 
-def test_digest_box_vectors_value_with_array():
+def test_digest_box_values_with_array():
     length_array_1 = np.array([1, 2, 3])
     lengths_expected = np.array([[1, 2, 3]])
-    lengths_digested = digest_box_vectors_value(length_array_1)
+    lengths_digested = digest_box_values(length_array_1)
     assert lengths_digested.shape == (1, 3)
     assert np.all(lengths_digested == lengths_expected)
 
     length_array_2 = np.array([[1, 2, 3],
                                [4, 5, 6]])
-    lengths_digested = digest_box_vectors_value(length_array_2)
+    lengths_digested = digest_box_values(length_array_2)
     assert lengths_digested.shape == (2, 3)
     assert np.all(lengths_digested == length_array_2)
 
 
-def test_digest_box_vectors_value_incorrect_shape_raises_error():
+def test_digest_box_values_incorrect_shape_raises_error():
     lengths_list = [1, 2, 3, 4]
     lengths_tuple = (1, 2, 3, 4)
 
     with pytest.raises(IncorrectShapeError):
-        digest_box_vectors_value(lengths_list)
+        digest_box_values(lengths_list)
 
     with pytest.raises(IncorrectShapeError):
-        digest_box_vectors_value(lengths_tuple)
+        digest_box_values(lengths_tuple)
 
     length_array_1 = np.array([1, 2, 3, 4])
     length_array_2 = np.array([[1],
@@ -53,17 +53,17 @@ def test_digest_box_vectors_value_incorrect_shape_raises_error():
     length_array_3 = np.array([[[1, 2, 3]]])
 
     with pytest.raises(IncorrectShapeError):
-        digest_box_vectors_value(length_array_1)
+        digest_box_values(length_array_1)
     with pytest.raises(IncorrectShapeError):
-        digest_box_vectors_value(length_array_2)
+        digest_box_values(length_array_2)
     with pytest.raises(IncorrectShapeError):
-        digest_box_vectors_value(length_array_3)
+        digest_box_values(length_array_3)
 
 
-def test_digest_box_vectors():
+def test_digest_box_lengths_or_angles():
 
     lengths = puw.quantity([1, 2, 3], "meters")
-    lengths_digested = digest_box_vectors(lengths)
+    lengths_digested = digest_box_lengths_or_angles(lengths)
     assert puw.get_value(lengths_digested).shape == (1, 3)
     assert np.all(puw.get_value(lengths_digested) == np.array([[1, 2, 3]]))
     assert puw.get_unit(lengths_digested) == "meter"
@@ -170,4 +170,3 @@ def test_indices_incorrect_value():
 
 def test_digest_item():
     pass
-


### PR DESCRIPTION
## Description
Renamed digest_box_vectors and readded the functions digest_box_lenghts and digest_box_angles (closes #59). 

## Todos
- The functions gest_box_lenghts and digest_box_angles were added again but they call a common method, as suggested in #59 
- It was also suggested that digest_box_vectors was renamed to digest_box. However, many methods call digest_box and doing this causes them to fail. digest_box will have to be implemented differently.

## Status
- [ ] Ready to go