### PR TITLE
Fixed comparison issuing warning with numpy arrays

### DIFF
--- a/molsysmt/basic/select.py
+++ b/molsysmt/basic/select.py
@@ -121,7 +121,7 @@ def select(molecular_system, selection='all', structure_index=0, element='atom',
     item: molecular model
         Molecular model in any supported form (see: :doc:`/Forms`). The object being acted on by the method.
 
-    selection: str, default='all'
+    selection: str, list, tuple, np.ndarray, default='all'
        Selection criterion given by means of a string following any of the selection syntaxis parsable by MolSysMT.
 
     mask: list, tuple, numpy array or None. default=None

--- a/molsysmt/basic/set.py
+++ b/molsysmt/basic/set.py
@@ -1,4 +1,4 @@
-# from molsysmt._private.digestion import *
+import numpy as np
 from molsysmt._private.digestion import digest
 
 
@@ -10,7 +10,6 @@ def set(molecular_system,
         structure_indices='all',
         syntaxis='MolSysMT',
         **kwargs):
-
     """into(item, element='system', indices=None, selection='all', structure_indices='all', syntaxis='MolSysMT')
 
     Set a new value to an attribute.
@@ -47,9 +46,7 @@ def set(molecular_system,
 
     Returns
     -------
-
     None
-        XXX.
 
     Examples
     --------
@@ -78,14 +75,16 @@ def set(molecular_system,
     # doing the work here
 
     if indices is None:
-        if selection != 'all':
-            indices = select(molecular_system, element=element, selection=selection,
-                    syntaxis=syntaxis, check=False)
+        if isinstance(selection, np.ndarray) or selection != 'all':
+            indices = select(molecular_system,
+                             element=element,
+                             selection=selection,
+                             syntaxis=syntaxis,
+                             check=False)
         else:
             indices = 'all'
 
     for attribute in attributes:
-
         item, form = where_is_attribute(molecular_system, attribute, check=False)
 
         value = value_of_attribute[attribute]


### PR DESCRIPTION
In `set.py` there was a line of code that could potentially compare a numpy array with a string, issuing a warning. This line of code was modified to check if the variable is a numpy array to prevent future errors. 

Closes #66 
