### PR TITLE
Iterator to work with trajectories

### DIFF
--- a/molsysmt/_private/exceptions/value_errors.py
+++ b/molsysmt/_private/exceptions/value_errors.py
@@ -212,6 +212,12 @@ class IteratorChunkSizeError(MolSysValueError):
     pass
 
 
+class IteratorStopError(MolSysValueError):
+    """ Exception raised when an incorrect stop value is passed to an iterator.
+    """
+    pass
+
+
 class ConcatenationError(MolSysValueError):
     """ Exception raised when two arrays cannot be concatenated because one if them is null.
     """

--- a/molsysmt/_private/exceptions/value_errors.py
+++ b/molsysmt/_private/exceptions/value_errors.py
@@ -6,7 +6,7 @@ api_doc = ''
 
 
 class MolSysValueError(ValueError):
-    """ Base class for value errors. Ir prints a message
+    """ Base class for value errors. It prints a message
         containing info such as the function that raised
         the error, and a link to GitHub repository.
 
@@ -192,3 +192,27 @@ class IncorrectShapeError(MolSysValueError):
         if actual_shape:
             message += f"Actual shape {actual_shape}. "
         super().__init__(message, caller)
+
+
+class IteratorStartError(MolSysValueError):
+    """ Exception raised when an incorrect start value is passed to an iterator.
+    """
+    pass
+
+
+class IteratorIntervalError(MolSysValueError):
+    """ Exception raised when an incorrect interval value is passed to an iterator.
+    """
+    pass
+
+
+class IteratorChunkSizeError(MolSysValueError):
+    """ Exception raised when an incorrect chunk size value is passed to an iterator.
+    """
+    pass
+
+
+class ConcatenationError(MolSysValueError):
+    """ Exception raised when two arrays cannot be concatenated because one if them is null.
+    """
+    pass

--- a/molsysmt/item/mdtraj_Trajectory/iterate.py
+++ b/molsysmt/item/mdtraj_Trajectory/iterate.py
@@ -1,0 +1,72 @@
+from molsysmt import puw
+from molsysmt._private.variables import is_all
+
+
+def iterate_mdtraj_trajectory(traj, start=0, stop=None,
+                              interval=1, selection="all", chunk_size=1):
+    """ Iterate a mdtraj Trajectory.
+
+        Parameters
+        ----------
+        traj : mdtraj.Trajectory
+            A trajectory
+
+        start: int
+            First frame index of the trajectory to start with.
+
+        stop: int, default=None
+            The iteration finishes if the current frame index
+            is larger than or equal to this integer.
+
+        interval : int, default=1
+            Number of structure indices to skip in each iteration
+
+        selection : arraylike of int or 'all', default='all'
+            The indices of the selected atoms.
+
+        chunk_size : int, default=1
+            Amount of frames in the output of each iteration.
+
+        Yields
+        ------
+        box : numpy.ndarray of shape (3, 3)
+                The box of the trajectory
+
+        coordinates : numpy.ndarray of shape (n_atoms, 3)
+            The coordinates of the trajectory.
+
+        time :  float
+            The time of the trajectory.
+    """
+    iter_end = traj.n_frames
+    if stop is not None:
+        iter_end = stop
+
+    if chunk_size > 1:
+        interval = chunk_size
+
+    for frame in range(start, iter_end, interval):
+        time = puw.quantity(traj.time[frame: frame + chunk_size],
+                            "picoseconds")
+
+        if is_all(selection):
+            if chunk_size == 1:
+                coords = puw.quantity(traj.xyz[frame], "nanometers")
+            else:
+                coords = puw.quantity(traj.xyz[frame: frame + chunk_size],
+                                      "nanometers")
+        else:
+            if chunk_size == 1:
+                coords = puw.quantity(traj.xyz[frame, selection, :], "nanometers")
+            else:
+                coords = puw.quantity(traj.xyz[frame: frame + chunk_size, selection, :],
+                                      "nanometers")
+
+        if chunk_size == 1:
+            box = puw.quantity(traj.unitcell_vectors[frame],
+                               "nanometers")
+        else:
+            box = puw.quantity(traj.unitcell_vectors[frame: frame + chunk_size],
+                               "nanometers")
+
+        yield time, coords, box

--- a/molsysmt/native/molsys.py
+++ b/molsysmt/native/molsys.py
@@ -1,5 +1,6 @@
 from molsysmt._private.variables import is_all
 
+
 class MolSys:
 
     def __init__(self):
@@ -28,11 +29,11 @@ class MolSys:
 
         from molsysmt import convert, get_form, select
 
-        if get_form(item)!='molsysmt.MolSys':
+        if get_form(item) != 'molsysmt.MolSys':
             tmp_item = convert(item, to_form='molsysmt.MolSys', selection=selection,
                                structure_indices=structure_indices, syntaxis=syntaxis)
             self.topology.add(tmp_item.topology)
-            self.structures.add(tmp_item.trajectory)
+            self.structures.add(tmp_item.structures)
         else:
             atom_indices=select(item, selection=selection, syntaxis=syntaxis)
             self.topology.add(item.topology, selection=atom_indices)

--- a/molsysmt/native/structures.py
+++ b/molsysmt/native/structures.py
@@ -314,6 +314,23 @@ class Structures:
 
         return step, time, coordinates, box
 
+    def _iterate_structures(self, start=0, stop=None,
+                            interval=1, selection="all", chunk_size=1):
+        """ Helper function for the iterate method."""
+        self._current_structure = start
+        while self._current_structure < self.n_structures:
+            if self._current_structure >= stop:
+                break
+
+            yield self.get_structure_data(self._current_structure,
+                                          selection,
+                                          chunk_size)
+
+            if chunk_size > 1:
+                self._current_structure += chunk_size
+            else:
+                self._current_structure += interval
+
     def iterate(self, start=0, stop=None,
                 interval=1, selection="all", chunk_size=1):
         """ Generator to iterate over the steps, time, coordinates and box
@@ -351,8 +368,6 @@ class Structures:
                 The times of the structure
 
         """
-        # TODO: argument checking is done in every iteration. It should be moved
-        #  to a different method.
         if start < 0 or start >= self.n_structures:
             raise exc.IteratorStartError(
                 f"Start should be > 0 and < {self.n_structures}"
@@ -380,19 +395,7 @@ class Structures:
                 f"Stop should be > 0 and < {self.n_structures}"
             )
 
-        self._current_structure = start
-        while self._current_structure < self.n_structures:
-            if self._current_structure >= stop:
-                break
-
-            yield self.get_structure_data(self._current_structure,
-                                          selection,
-                                          chunk_size)
-
-            if chunk_size > 1:
-                self._current_structure += chunk_size
-            else:
-                self._current_structure += interval
+        return self._iterate_structures(start, stop, interval, selection, chunk_size)
 
     def copy(self):
         """ Returns a copy of the structures."""

--- a/molsysmt/native/structures.py
+++ b/molsysmt/native/structures.py
@@ -362,6 +362,11 @@ class Structures:
         if stop is None:
             stop = self.n_structures
 
+        if stop < 1 or stop > self.n_structures:
+            raise exc.IteratorStopError(
+                f"Stop should be > 0 and < {self.n_structures}"
+            )
+
         self._current_structure = start
         while self._current_structure < self.n_structures:
             if self._current_structure >= stop:

--- a/molsysmt/native/structures.py
+++ b/molsysmt/native/structures.py
@@ -232,9 +232,15 @@ class Structures:
                 Select only these structures from the given item
         """
 
-        step, time, coordinate, box = get(item, element="atom", selection=selection,
-                                          structure_indices=structure_indices, frame=True)
-        self.append_structures(step, time, coordinate, box)
+        step, time, coordinates, box = get(item,
+                                           selection=selection,
+                                           structure_indices=structure_indices,
+                                           step=True,
+                                           time=True,
+                                           coordinates=True,
+                                           box=True
+                                           )
+        self.append_structures(step, time, coordinates, box)
 
     def copy(self):
         """ Returns a copy of the structures."""

--- a/molsysmt/native/structures.py
+++ b/molsysmt/native/structures.py
@@ -290,14 +290,25 @@ class Structures:
 
         if self.coordinates is not None:
             if is_all(selection):
-                coordinates = self.coordinates[structure: structure_end]
+                # If chunk size is 1 we return a 2D array. If not coordinates will
+                # be a 3D array
+                if chunk_size == 1:
+                    coordinates = self.coordinates[structure]
+                else:
+                    coordinates = self.coordinates[structure: structure_end]
             else:
-                coordinates = self.coordinates[structure: structure_end, selection, :]
+                if chunk_size == 1:
+                    coordinates = self.coordinates[structure, selection, :]
+                else:
+                    coordinates = self.coordinates[structure: structure_end, selection, :]
         else:
             coordinates = None
 
         if self.box is not None:
-            box = self.box[structure: structure_end]
+            if chunk_size == 1:
+                box = self.box[structure]
+            else:
+                box = self.box[structure: structure_end]
         else:
             box = None
 
@@ -340,6 +351,8 @@ class Structures:
                 The times of the structure
 
         """
+        # TODO: argument checking is done in every iteration. It should be moved
+        #  to a different method.
         if start < 0 or start >= self.n_structures:
             raise exc.IteratorStartError(
                 f"Start should be > 0 and < {self.n_structures}"

--- a/molsysmt/native/structures.py
+++ b/molsysmt/native/structures.py
@@ -1,44 +1,60 @@
 import numpy as np
 from molsysmt import puw
-from molsysmt._private.exceptions import *
 from molsysmt._private.variables import is_all
 
-# Tiene que haber una manera automatica con f2py dar siempre de salida Ccontiguous_np.arrays
 
-# Un frame tiene: step, time, coordinates, cell
+class Structures:
+    """ Class to store the trajectory info of a molecular system
 
-class Structures():
+        Parameters
+        ----------
+        filepath : str
+
+        atom_indices : Any
+
+        structure_indices: Any
+
+        Attributes
+        ----------
+        box :
+
+        coordinates : pint.Quantity of shape (n_structures, n_atoms, 3)
+            The coordinates of the trajectory for each frame of it.
+
+
+    """
 
     def __init__(self, filepath=None, atom_indices='all', structure_indices='all'):
 
-        self.step  = None
-        self.time  = None
-        self.coordinates = None # ndarray with shape=(n_structures, n_atoms, 3) and dtype=float
-                                # and order=F, with units nanometers
-        self.box  = None # ndarray with shape=(n_structures,3,3), dtype=float and order='F'
-                          # cell is the matrix with the vectors
+        self.step = None
+        self.time = None
+        self.coordinates = None  # ndarray with shape=(n_structures, n_atoms, 3) and dtype=float
+        # and order=F, with units nanometers
+        self.box = None  # ndarray with shape=(n_structures,3,3), dtype=float and order='F'
+        # cell is the matrix with the vectors
         self.n_structures = 0
         self.n_atoms = 0
 
         self.file = None
 
         if filepath is not None:
-            self.load_frames_from_file(filepath=filepath, atom_indices=atom_indices, structure_indices=structure_indices)
+            self.load_frames_from_file(filepath=filepath, atom_indices=atom_indices,
+                                       structure_indices=structure_indices)
 
     def append_structures(self, step=None, time=None, coordinates=None, box=None, check=True):
 
         if step is not None:
             if type(step) not in [list, np.ndarray]:
-                step  = np.array([step])
+                step = np.array([step])
             else:
                 step = step
 
         if time is not None:
-            time=puw.standardize(time)
+            time = puw.standardize(time)
         if coordinates is not None:
-            coordinates=puw.standardize(coordinates)
+            coordinates = puw.standardize(coordinates)
         if box is not None:
-            box=puw.standardize(box)
+            box = puw.standardize(box)
 
         n_structures = coordinates.shape[0]
         n_atoms = coordinates.shape[1]
@@ -54,7 +70,7 @@ class Structures():
 
         else:
 
-            if n_atoms!=self.n_atoms:
+            if n_atoms != self.n_atoms:
                 raise ValueError("The coordinates to be appended in the system needs to have the same number of atoms.")
 
             if step is not None:
@@ -103,22 +119,22 @@ class Structures():
 
         return angles
 
-    def load_structures_from_file (self, filepath=None, atom_indices='all', structure_indices='all'):
+    def load_structures_from_file(self, filepath=None, atom_indices='all', structure_indices='all'):
 
         if filepath is not None:
-
             from .trajectory_file import TrajectoryFile
             self.file = TrajectoryFile(filepath=filepath)
 
-        step, time, coordinates, box = self.file.read_frames(atom_indices=atom_indices, structure_indices=structure_indices)
+        step, time, coordinates, box = self.file.read_frames(atom_indices=atom_indices,
+                                                             structure_indices=structure_indices)
 
         self.append_structures(step, time, coordinates, box)
 
-        del(coordinates, time, step, box)
+        del (coordinates, time, step, box)
 
         pass
 
-    def extract (self, atom_indices='all', structure_indices='all'):
+    def extract(self, atom_indices='all', structure_indices='all'):
 
         if is_all(atom_indices) and is_all(structure_indices):
 
@@ -149,12 +165,12 @@ class Structures():
                     tmp_item.box = deepcopy(self.box)
 
             if not is_all(atom_indices):
-                tmp_item.coordinates = self.coordinates[:,atom_indices,:]
+                tmp_item.coordinates = self.coordinates[:, atom_indices, :]
             else:
                 tmp_item.coordinates = deepcopy(self.coordinates)
 
             if not is_all(structure_indices):
-                tmp_item.coordinates = tmp_item.coordinates[structure_indices,:,:]
+                tmp_item.coordinates = tmp_item.coordinates[structure_indices, :, :]
 
             tmp_item.n_structures = tmp_item.coordinates.shape[0]
             tmp_item.n_atoms = tmp_item.coordinates.shape[1]
@@ -173,7 +189,7 @@ class Structures():
         coordinates = get(item, element="atom", selection=selection, structure_indices=structure_indices,
                           coordinates=True)
 
-        if self.n_structures==0:
+        if self.n_structures == 0:
             self.append_structures(step, time, coordinates, box)
         else:
             if self.n_structures != coordinates.shape[0]:
@@ -182,8 +198,8 @@ class Structures():
                 unit = puw.get_unit(self.coordinates)
                 value_coordinates = puw.get_value(coordinates, to_unit=unit)
                 value_self_coordinates = puw.get_value(self.coordinates)
-                self.coordinates = np.hstack([value_self_coordinates, value_coordinates])*unit
-                del(value_coordinates, value_self_coordinates)
+                self.coordinates = np.hstack([value_self_coordinates, value_coordinates]) * unit
+                del (value_coordinates, value_self_coordinates)
 
         self.n_atoms = self.coordinates.shape[1]
 
@@ -199,7 +215,7 @@ class Structures():
 
         pass
 
-    def copy (self):
+    def copy(self):
 
         from copy import deepcopy
 
@@ -220,20 +236,19 @@ class Structures():
 
         return tmp_item
 
-
-    #def cell2box(self):
+    # def cell2box(self):
     #    self.box,self.volume,self.orthogonal=_libbox.cell2box(self.cell, self.n_structures)
     #    pass
 
-    #def box2cell(self):
+    # def box2cell(self):
     #    self.cell,self.volume,self.orthogonal=_libbox.box2cell(self.box, self.n_structures)
     #    pass
 
-    #def box2invbox(self):
+    # def box2invbox(self):
     #    self.invbox=_libbox.box2invbox(self.box, self.n_structures)
     #    pass
 
-    #def iterload(self, chunk=100, stride=1, skip=0, atom_indices=None):
+    # def iterload(self, chunk=100, stride=1, skip=0, atom_indices=None):
 
     #    atom_indices = None
 
@@ -260,4 +275,3 @@ class Structures():
     #            self._import_mdtraj_topology(tmp_mdtraj)
     #        del(tmp_mdtraj)
     #        yield
-

--- a/molsysmt/structure/__init__.py
+++ b/molsysmt/structure/__init__.py
@@ -18,4 +18,4 @@ from .get_least_rmsd import get_least_rmsd
 from .fit import fit
 from .align import align
 from .get_sasa import get_sasa
-
+from .iterator import Iterator

--- a/molsysmt/structure/iterator.py
+++ b/molsysmt/structure/iterator.py
@@ -86,8 +86,9 @@ class Iterator:
         form = get_form(item)
         if form == "molsysmt.MolSys" or form == "molsysmt.Structures":
             return item, form
-        elif form.startswith("file"):
+        elif isinstance(form, list) or form.startswith("file"):
             return convert(item, to_form="molsysmt.MolSys"), "molsysmt.MolSys"
+
         else:
             raise MolSysNotImplementedError(
                 f"Iterator has not been implemented for form {form}")

--- a/molsysmt/structure/iterator.py
+++ b/molsysmt/structure/iterator.py
@@ -1,4 +1,5 @@
 from molsysmt import get_form, convert
+from molsysmt.item.mdtraj_Trajectory.iterate import iterate_mdtraj_trajectory
 from molsysmt._private.exceptions.not_implemented_errors import MolSysNotImplementedError
 import molsysmt._private.exceptions.value_errors as exc
 
@@ -84,7 +85,8 @@ class Iterator:
     def _get_molecular_system_and_form(item):
         """ Returns a molecular system. """
         form = get_form(item)
-        if form == "molsysmt.MolSys" or form == "molsysmt.Structures":
+        if form == "molsysmt.MolSys" or form == "molsysmt.Structures"\
+                or form == "mdtraj.Trajectory":
             return item, form
         elif isinstance(form, list) or form.startswith("file"):
             return convert(item, to_form="molsysmt.MolSys"), "molsysmt.MolSys"
@@ -113,6 +115,15 @@ class Iterator:
                 selection=self._selection,
                 chunk_size=self._chunk_size
             )
+        elif self._form == "mdtraj.Trajectory":
+            return iterate_mdtraj_trajectory(
+                self.molecular_system,
+                start=self._start,
+                stop=self._stop,
+                interval=self._interval,
+                selection=self._selection,
+                chunk_size=self._chunk_size
+            )
         else:
             raise MolSysNotImplementedError(
                 f"Iterator has not been implemented for form {self._form}")
@@ -121,7 +132,7 @@ class Iterator:
         """ Returns the number of atoms in the molecular system."""
         if self._form == "molsysmt.MolSys":
             return self.molecular_system.structures.n_atoms
-        elif self._form == "molsysmt.Structures":
+        elif self._form == "molsysmt.Structures" or self._form == "mdtraj.Trajectory":
             return self.molecular_system.n_atoms
         else:
             raise MolSysNotImplementedError(
@@ -133,6 +144,8 @@ class Iterator:
             return self.molecular_system.structures.n_structures
         elif self._form == "molsysmt.Structures":
             return self.molecular_system.n_structures
+        elif self._form == "mdtraj.Trajectory":
+            return self.molecular_system.n_frames
         else:
             raise MolSysNotImplementedError(
                 f"Iterator has not been implemented for form {self._form}")

--- a/molsysmt/structure/iterator.py
+++ b/molsysmt/structure/iterator.py
@@ -1,0 +1,21 @@
+
+
+class Iterator:
+    """ A class that allows to iterate trough trajectories of any type.
+    """
+    def __init__(self,
+                 molecular_system,
+                 start=0,
+                 interval=1,
+                 stop=None,
+                 chunk_size=None,
+                 selection="all",
+                 syntaxis="MolSysMT"
+                 ):
+        pass
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return 1.0, 1.0, [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]

--- a/molsysmt/structure/iterator.py
+++ b/molsysmt/structure/iterator.py
@@ -1,3 +1,6 @@
+from molsysmt import get_form, convert
+from molsysmt._private.exceptions.not_implemented_errors import MolSysNotImplementedError
+import molsysmt._private.exceptions.value_errors as exc
 
 
 class Iterator:
@@ -8,14 +11,133 @@ class Iterator:
                  start=0,
                  interval=1,
                  stop=None,
-                 chunk_size=None,
+                 chunk_size=1,
                  selection="all",
                  syntaxis="MolSysMT"
                  ):
-        pass
+        self._molecular_system, self._form = self._get_molecular_system_and_form(molecular_system)
+        self._start = start
+        self._interval = interval
+        self._stop = stop
+        self._chunk_size = chunk_size
+        self._selection = selection
+
+        self._n_atoms = self._get_num_atoms()
+        self._n_structures = self._get_num_structures()
+
+        self._iterator = self._get_iterator()
+
+    @property
+    def molecular_system(self):
+        """ Returns the molecular system this iterator is associated with.
+        """
+        return self._molecular_system
+
+    @property
+    def start(self):
+        return self._start
+
+    @start.setter
+    def start(self, start):
+        if start < 0 or start >= self._n_structures:
+            raise exc.IteratorStartError(
+                f"Start should be > 0 and < {self._n_structures}"
+            )
+        self._start = start
+
+    @property
+    def interval(self):
+        return self._interval
+
+    @interval.setter
+    def interval(self, interval):
+        if interval < 1 or interval > self._n_structures:
+            raise exc.IteratorIntervalError(
+                f"Interval should be > 0 and < {self._n_structures}"
+            )
+        self._interval = interval
+
+    @property
+    def stop(self):
+        return self._stop
+
+    @stop.setter
+    def stop(self, stop):
+        if stop < 1 or stop > self._n_structures:
+            raise exc.IteratorStopError(
+                f"Stop should be > 0 and < {self._n_structures}"
+            )
+        self._stop = stop
+
+    @property
+    def chunk_size(self):
+        return self._chunk_size
+
+    @chunk_size.setter
+    def chunk_size(self, chunk_size):
+        if chunk_size < 1 or chunk_size > self._n_structures:
+            raise exc.IteratorChunkSizeError(
+                f"Chunk size should be > 0 and < {self._n_structures}")
+        self._chunk_size = chunk_size
+
+    @staticmethod
+    def _get_molecular_system_and_form(item):
+        """ Returns a molecular system. """
+        form = get_form(item)
+        if form == "molsysmt.MolSys" or form == "molsysmt.Structures":
+            return item, form
+        elif form.startswith("file"):
+            return convert(item, to_form="molsysmt.MolSys"), "molsysmt.MolSys"
+        else:
+            raise MolSysNotImplementedError(
+                f"Iterator has not been implemented for form {form}")
+
+    def _get_iterator(self):
+        """ Returns a generator function corresponding to the
+            molecular system form passed
+        """
+        if self._form == "molsysmt.MolSys":
+            return self.molecular_system.structures.iterate(
+                start=self._start,
+                stop=self._stop,
+                interval=self._interval,
+                selection=self._selection,
+                chunk_size=self._chunk_size
+            )
+        elif self._form == "molsysmt.Structures":
+            return self.molecular_system.iterate(
+                start=self._start,
+                stop=self._stop,
+                interval=self._interval,
+                selection=self._selection,
+                chunk_size=self._chunk_size
+            )
+        else:
+            raise MolSysNotImplementedError(
+                f"Iterator has not been implemented for form {self._form}")
+
+    def _get_num_atoms(self):
+        """ Returns the number of atoms in the molecular system."""
+        if self._form == "molsysmt.MolSys":
+            return self.molecular_system.structures.n_atoms
+        elif self._form == "molsysmt.Structures":
+            return self.molecular_system.n_atoms
+        else:
+            raise MolSysNotImplementedError(
+                f"Iterator has not been implemented for form {self._form}")
+
+    def _get_num_structures(self):
+        """ Returns the number of atoms in the molecular system."""
+        if self._form == "molsysmt.MolSys":
+            return self.molecular_system.structures.n_structures
+        elif self._form == "molsysmt.Structures":
+            return self.molecular_system.n_structures
+        else:
+            raise MolSysNotImplementedError(
+                f"Iterator has not been implemented for form {self._form}")
 
     def __iter__(self):
-        return self
+        return self._iterator
 
     def __next__(self):
-        return 1.0, 1.0, [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]
+        return next(self._iterator)

--- a/molsysmt/tests/item/test_iterate_mdtraj.py
+++ b/molsysmt/tests/item/test_iterate_mdtraj.py
@@ -1,0 +1,159 @@
+from molsysmt.item.mdtraj_Trajectory.iterate import iterate_mdtraj_trajectory
+import molsysmt as msm
+from molsysmt import puw
+import numpy as np
+import mdtraj as mdt
+import mdtraj.core.element as mdt_element
+import pytest
+
+
+@pytest.fixture()
+def mdtraj_trajectory_with_five_frames():
+    """ Returns a mdtraj trajectory with five frames and
+        five atoms
+    """
+    coordinates = np.ones((5, 5, 3), dtype="float")
+    for ii in range(coordinates.shape[0]):
+        coordinates[ii] *= (ii * 1.)
+
+    angles = np.ones((5, 3), dtype="float")
+    lengths = np.ones((5, 3), dtype="float")
+    for ii in range(angles.shape[0]):
+        angles[ii] *= np.radians(ii + 1 * 20.)
+        lengths[ii] *= (ii * 1.)
+
+    time = np.arange(50., step=10.)
+
+    # The trajectory needs a topology to be instantiated. We create
+    # a mock topology with five atoms.
+    topology = mdt.Topology()
+    chain = topology.add_chain()
+    residue = topology.add_residue("ALA", chain)
+    element = mdt_element.carbon
+    for ii in range(coordinates.shape[0]):
+        topology.add_atom("CA", element, residue)
+
+    return mdt.Trajectory(xyz=coordinates,
+                          time=time,
+                          topology=topology,
+                          unitcell_angles=angles,
+                          unitcell_lengths=lengths
+                          )
+
+
+def iterate_structure(iterator,
+                      expected_iterations,
+                      start=0,
+                      selection=None,
+                      interval=1):
+    n_iterations = 0
+    ii = start
+    for time, coordinates, box in iterator:
+
+        expected_coordinates = np.ones((5, 3), dtype="float") * ii * 1.
+
+        if selection is not None:
+            expected_coordinates = expected_coordinates[selection, :]
+            assert coordinates.shape == (len(selection), 3)
+        else:
+            assert coordinates.shape == (5, 3)
+
+        assert puw.get_value(time) == ii * 10.
+        assert np.allclose(puw.get_value(coordinates),
+                           expected_coordinates)
+        assert box.shape == (3, 3)
+
+        ii += interval
+        n_iterations += 1
+
+    assert n_iterations == expected_iterations
+
+
+def test_iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames):
+
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames)
+    iterate_structure(iterator,
+                      expected_iterations=5)
+
+    # Iterate with a custom stop
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames,
+                                         stop=3)
+    iterate_structure(iterator,
+                      expected_iterations=3)
+
+    # Iterate with custom start
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames,
+                                         start=2)
+    iterate_structure(iterator,
+                      expected_iterations=3,
+                      start=2)
+
+    # Iterate with custom start and stop
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames,
+                                         start=1,
+                                         stop=4)
+    iterate_structure(iterator,
+                      expected_iterations=3,
+                      start=1)
+
+    # Iterate with custom selection
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames,
+                                         selection=[0, 2, 4])
+    iterate_structure(iterator,
+                      expected_iterations=5,
+                      selection=[0, 2, 4],
+                      )
+
+    # Iterate with custom interval
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames,
+                                         interval=2)
+    iterate_structure(iterator,
+                      expected_iterations=3,
+                      interval=2
+                      )
+
+
+def test_iterate_mdtraj_with_custom_chunk_size(mdtraj_trajectory_with_five_frames):
+    iterator = iterate_mdtraj_trajectory(mdtraj_trajectory_with_five_frames,
+                                         chunk_size=2)
+
+    time, coords, box = next(iterator)
+    assert np.all(puw.get_value(time) == np.array([0., 10.]))
+    assert box.shape == (2, 3, 3)
+    assert coords.shape == (2, 5, 3)
+    assert np.all(puw.get_value(coords[0]) == np.zeros((5, 3), dtype="float"))
+    assert np.all(puw.get_value(coords[1]) == np.ones((5, 3), dtype="float"))
+
+    time, coords, box = next(iterator)
+    assert np.all(puw.get_value(time) == np.array([20., 30.]))
+    assert box.shape == (2, 3, 3)
+    assert coords.shape == (2, 5, 3)
+    assert np.all(puw.get_value(coords[0]) == np.ones((5, 3), dtype="float") * 2.)
+    assert np.all(puw.get_value(coords[1]) == np.ones((5, 3), dtype="float") * 3.)
+
+    time, coords, box = next(iterator)
+    assert np.all(puw.get_value(time) == np.array([40.]))
+    assert box.shape == (1, 3, 3)
+    assert coords.shape == (1, 5, 3)
+    assert np.all(puw.get_value(coords[0]) == np.ones((1, 5, 3), dtype="float") * 4.)
+
+
+def test_iterate_pentalanine_with_mdtraj_trajectory():
+    traj = mdt.load(msm.demo["pentalanine"]["traj.h5"])
+
+    n_iterations = 0
+    expected_time = 10.
+    iterator = iterate_mdtraj_trajectory(traj)
+    for time, coordinates, box in iterator:
+        assert puw.get_value(time) == expected_time
+        assert coordinates.shape == (62, 3)
+        assert box.shape == (3, 3)
+
+        expected_time += 10.
+        n_iterations += 1
+
+    assert puw.get_unit(time) == "picosecond"
+    assert puw.get_unit(coordinates) == "nanometer"
+    assert puw.get_unit(box) == "nanometer"
+
+    assert n_iterations == 5000

--- a/molsysmt/tests/native/test_structures.py
+++ b/molsysmt/tests/native/test_structures.py
@@ -1,0 +1,88 @@
+from molsysmt.native import Structures
+from molsysmt import puw
+import numpy as np
+import pytest
+
+
+@pytest.fixture()
+def structures_with_one_frame():
+    coords = np.array([[[1., 2., 3.],
+                        [1., 0., 1.]]])
+    box = np.array([[[1., 0., 0.],
+                     [0., 1., 0.],
+                     [0., 0., 1.]]])
+    coords = puw.quantity(coords, "nanometers")
+    time = puw.quantity(np.array([10.]), "picoseconds")
+    box = puw.quantity(box, "nanometers")
+
+    return Structures(coordinates=coords, time=time, box=box)
+
+
+def test_structures_constructor(structures_with_one_frame):
+    assert structures_with_one_frame.n_atoms == 2
+    assert structures_with_one_frame.n_structures == 1
+
+
+def test_append_structures(structures_with_one_frame):
+    coords = np.array([[[0., 1., 1.],
+                        [2., 0., 1.]]])
+    coords = puw.quantity(coords, "nanometers")
+    time = puw.quantity(np.array([20.]), "picoseconds")
+    box = np.array([[[1.5, 0., 0.],
+                     [0., 1.4, 0.],
+                     [0., 0., 1.4]]])
+    box = puw.quantity(box, "nanometers")
+
+    structure = structures_with_one_frame.copy()
+    structure.append_structures(coordinates=coords,
+                                time=time,
+                                box=box)
+
+    coords_expected = np.array([
+        [[1., 2., 3.],
+         [1., 0., 1.]],
+        [[0., 1., 1.],
+         [2., 0., 1.]]
+    ])
+    assert coords_expected.shape == (2, 2, 3)
+    box_expected = np.array([
+        [[1., 0., 0.],
+         [0., 1., 0.],
+         [0., 0., 1.]],
+        [[1.5, 0., 0.],
+         [0., 1.4, 0.],
+         [0., 0., 1.4]]
+    ])
+    assert box_expected.shape == (2, 3, 3)
+
+    assert structure.n_structures == 2
+    assert structure.n_atoms == 2
+
+    assert structure.time.shape[0] == 2
+    assert np.allclose(puw.get_value(structure.time),
+                       np.array([10., 20.]))
+
+    assert structure.coordinates.shape == (2, 2, 3)
+    assert np.allclose(puw.get_value(structure.coordinates),
+                       coords_expected)
+
+    assert structure.box.shape == (2, 3, 3)
+    assert np.allclose(puw.get_value(structure.box),
+                       box_expected)
+
+
+def test_copy(structures_with_one_frame):
+
+    structures_copy = structures_with_one_frame.copy()
+    assert structures_copy.n_structures == 1
+    assert structures_copy.n_atoms == 2
+    assert structures_copy.box.shape == (1, 3, 3)
+    assert structures_copy.coordinates.shape == (1, 2, 3)
+
+
+def test_extract():
+    pass
+
+
+def test_add():
+    pass

--- a/molsysmt/tests/native/test_structures.py
+++ b/molsysmt/tests/native/test_structures.py
@@ -209,6 +209,8 @@ def iterate_structure(iterator,
 
         if selection is not None:
             expected_coordinates = expected_coordinates[selection, :]
+        else:
+            assert coordinates.shape == (3, 3)
 
         assert step is None
         assert puw.get_value(time) == ii * 10.

--- a/molsysmt/tests/native/test_structures.py
+++ b/molsysmt/tests/native/test_structures.py
@@ -346,9 +346,9 @@ def test_iterate_with_custom_chunk_size(structure_with_five_frames):
     iterator_3 = structure_with_five_frames.iterate(chunk_size=5)
     n_iters = 0
     for step, times, coordinates, box in iterator_3:
-        assert times == structures.time
-        assert coordinates == structures.time
-        assert box == structures.box
+        assert np.all(times == structures.time)
+        assert np.all(coordinates == structures.coordinates)
+        assert np.all(box == structures.box)
         n_iters += 1
 
     assert n_iters == 1

--- a/molsysmt/tests/native/test_structures.py
+++ b/molsysmt/tests/native/test_structures.py
@@ -154,9 +154,12 @@ def test_extract_structures(structure_with_five_frames):
 
 def test_add():
 
-    proline = msm.convert(msm.demo['proline dipeptide']['vacuum.msmpk'], to_form='molsysmt.MolSys')
-    valine = msm.convert(msm.demo['valine dipeptide']['vacuum.msmpk'], to_form='molsysmt.MolSys')
-    lysine = msm.convert(msm.demo['lysine dipeptide']['vacuum.msmpk'], to_form='molsysmt.MolSys')
+    proline = msm.convert(msm.demo['proline dipeptide']['vacuum.msmpk'],
+                          to_form='molsysmt.MolSys')
+    valine = msm.convert(msm.demo['valine dipeptide']['vacuum.msmpk'],
+                         to_form='molsysmt.MolSys')
+    lysine = msm.convert(msm.demo['lysine dipeptide']['vacuum.msmpk'],
+                         to_form='molsysmt.MolSys')
 
     structures = Structures()
     structures.add(proline)
@@ -165,9 +168,31 @@ def test_add():
     assert structures.coordinates.shape == (1, 26, 3)
 
     structures.add(valine)
+    assert structures.n_structures == 1
+    assert structures.n_atoms == 54
+    assert structures.coordinates.shape == (1, 54, 3)
 
     structures.add(lysine)
+    assert structures.n_structures == 1
+    assert structures.n_atoms == 88
+    assert structures.coordinates.shape == (1, 88, 3)
 
 
 def test_append():
-    pass
+
+    proline = msm.convert(msm.demo['proline dipeptide']['vacuum.msmpk'],
+                          to_form='molsysmt.MolSys')
+
+    proline_translated_1 = msm.structure.translate(proline,
+                                                   translation='[0.1, 0.1, 0.1] nanometers')
+    proline_translated_2 = msm.structure.translate(proline,
+                                                   translation='[0.2, 0.2, 0.2] nanometers')
+    structures = Structures()
+    structures.add(proline)
+    structures.append(proline_translated_1)
+    assert structures.n_atoms == 26
+    assert structures.coordinates.shape == (2, 26, 3)
+
+    structures.append(proline_translated_2)
+    assert structures.n_atoms == 26
+    assert structures.coordinates.shape == (3, 26, 3)

--- a/molsysmt/tests/native/test_structures.py
+++ b/molsysmt/tests/native/test_structures.py
@@ -1,3 +1,4 @@
+import molsysmt as msm
 from molsysmt.native import Structures
 from molsysmt import puw
 import numpy as np
@@ -16,6 +17,25 @@ def structures_with_one_frame():
     box = puw.quantity(box, "nanometers")
 
     return Structures(coordinates=coords, time=time, box=box)
+
+
+@pytest.fixture()
+def structure_with_five_frames():
+    coords = np.array(range(45))
+    coords = coords.reshape((5, 3, 3)) * 0.1
+    coords = puw.quantity(coords, "nanometers")
+    box = np.zeros((5, 3, 3))
+    for ii in range(box.shape[0]):
+        for jj in range(box.shape[1]):
+            box[ii, jj, jj] = ii * 1.
+    box = puw.quantity(box, "nanometers")
+    time = np.array(range(0, 5)) * 10.0
+    assert time.shape == (5,)
+
+    return Structures(coordinates=coords,
+                      time=time,
+                      box=box
+                      )
 
 
 def test_structures_constructor(structures_with_one_frame):
@@ -80,9 +100,74 @@ def test_copy(structures_with_one_frame):
     assert structures_copy.coordinates.shape == (1, 2, 3)
 
 
-def test_extract():
-    pass
+def test_extract_atoms(structure_with_five_frames):
+
+    structures = structure_with_five_frames.copy()
+    structures_extracted_atoms = structures.extract(atom_indices=[0, 1])
+
+    assert structures_extracted_atoms.n_atoms == 2
+    assert structures_extracted_atoms.n_structures == 5
+    assert structures_extracted_atoms.coordinates.shape == (5, 2, 3)
+    assert structures_extracted_atoms.box.shape == (5, 3, 3)
+
+    coordinates_expected = np.array(range(45)).reshape((5, 3, 3))
+    coordinates_expected = coordinates_expected[:, 0:2, :] * 0.1
+    assert np.allclose(puw.get_value(structures_extracted_atoms.coordinates),
+                       coordinates_expected)
+    assert np.allclose(structures_extracted_atoms.time,
+                       np.array(range(0, 5)) * 10.
+                       )
+
+
+def test_extract_structures(structure_with_five_frames):
+
+    structure_extracted = structure_with_five_frames.copy().extract(
+        structure_indices=[0, 2, 4]
+    )
+
+    assert structure_extracted.n_atoms == 3
+    assert structure_extracted.n_structures == 3
+    assert structure_extracted.coordinates.shape == (3, 3, 3)
+    assert structure_extracted.box.shape == (3, 3, 3)
+
+    assert np.allclose(structure_extracted.time,
+                       np.array([0., 20., 40.])
+                       )
+    coordinates_expected = np.array(range(45)).reshape((5, 3, 3))
+    coordinates_expected = coordinates_expected[[0, 2, 4], :, :] * 0.1
+    assert np.allclose(puw.get_value(structure_extracted.coordinates),
+                       coordinates_expected)
+
+    box = puw.get_value(structure_extracted.box)
+    assert np.allclose(box[0], np.zeros((3, 3)))
+    assert np.allclose(box[1],
+                       np.array([[2., 0., 0.],
+                                 [0., 2., 0.],
+                                 [0., 0., 2.]])
+                       )
+    assert np.allclose(box[2],
+                       np.array([[4., 0., 0.],
+                                 [0., 4., 0.],
+                                 [0., 0., 4.]])
+                       )
 
 
 def test_add():
+
+    proline = msm.convert(msm.demo['proline dipeptide']['vacuum.msmpk'], to_form='molsysmt.MolSys')
+    valine = msm.convert(msm.demo['valine dipeptide']['vacuum.msmpk'], to_form='molsysmt.MolSys')
+    lysine = msm.convert(msm.demo['lysine dipeptide']['vacuum.msmpk'], to_form='molsysmt.MolSys')
+
+    structures = Structures()
+    structures.add(proline)
+    assert structures.n_structures == 1
+    assert structures.n_atoms == 26
+    assert structures.coordinates.shape == (1, 26, 3)
+
+    structures.add(valine)
+
+    structures.add(lysine)
+
+
+def test_append():
     pass

--- a/molsysmt/tests/structure/iterator/test_iterator.py
+++ b/molsysmt/tests/structure/iterator/test_iterator.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import molsysmt as msm
 
 
@@ -75,7 +74,7 @@ def test_iterator_with_h5_file():
 
 def test_iterator_with_gromacs_file():
     traj_file = msm.demo['nglview']['md_1u19.gro']
-    topology_file = msm.demo['nglview']['md_1u19.gro']
+    topology_file = msm.demo['nglview']['md_1u19.pdb']
 
     iterator = msm.structure.Iterator([traj_file, topology_file])
     assert iterator.n_atoms == 5547
@@ -98,3 +97,23 @@ def test_iterator_with_gromacs_file():
                           [0., 7.988997, 0.],
                           [0., 0., 9.910033]])
     assert np.allclose(box, final_box)
+
+
+def test_iterator_with_custom_start():
+    pass
+
+
+def test_iterator_with_custom_interval():
+    pass
+
+
+def test_iterator_with_custom_chunk_size():
+    pass
+
+
+def test_iterator_with_custom_selection():
+    pass
+
+
+def test_iterator_with_custom_syntaxis():
+    pass

--- a/molsysmt/tests/structure/iterator/test_iterator.py
+++ b/molsysmt/tests/structure/iterator/test_iterator.py
@@ -79,56 +79,71 @@ def test_iterator_number_of_structures(pentalanine_iterator,
     assert iterator._get_num_structures() == 5000
 
 
+def check_iterator_coordinates_time_and_box(iterator,
+                                            expected_time,
+                                            expected_coords,
+                                            expected_coords_shape,
+                                            expected_box):
+
+    _, time, coordinates, box = next(iterator)
+    assert puw.get_value(time) == expected_time
+    assert coordinates.shape == expected_coords_shape
+    assert np.allclose(puw.get_value(coordinates[0:5]),
+                       expected_coords)
+
+    assert box.shape == (3, 3)
+    assert np.allclose(puw.get_value(box),
+                       expected_box)
+
+
 def test_iterator_with_h5_file():
     pentalanine_file = msm.demo["pentalanine"]["traj.h5"]
 
     iterator = msm.structure.Iterator(pentalanine_file)
-    _, time, coordinates, box = next(iterator)
-    assert puw.get_value(time) == 10.
-    assert coordinates.shape == (62, 3)
-    # We only test coordinates of first five atoms for simplicity
+    # We only test the first 5 atoms for simplicity
     timestep_coords = np.array([[0.7249491, 0.28118464, -0.06514733],
                                 [0.8183724, 0.33541468, -0.07971666],
                                 [0.82463497, 0.38432965, -0.17692305],
                                 [0.88794595, 0.25160828, -0.08384151],
                                 [0.8513755, 0.42293516, 0.03777996]])
-    assert np.allclose(coordinates[0:5], timestep_coords)
-
-    assert box.shape == (3, 3)
     timestep_box = np.array([[2., 0., 0.],
                              [0., 2., 0.],
                              [0., 0., 2.]])
-    assert np.allclose(box, timestep_box)
+    check_iterator_coordinates_time_and_box(
+        iterator,
+        10.,
+        timestep_coords,
+        (62, 3),
+        timestep_box
+    )
 
-    _, time, coordinates, box = next(iterator)
-    assert puw.get_value(time) == 20.
-    assert coordinates.shape == (62, 3)
-    # We only test coordinates of first five atoms for simplicity
     timestep_coords = np.array([[0.49193183, 0.3567681, 0.28309438],
                                 [0.49901953, 0.46519688, 0.2916948],
                                 [0.58446306, 0.4869771, 0.35577384],
                                 [0.41150057, 0.51321983, 0.33545825],
                                 [0.5144549, 0.5183858, 0.15133896]])
-    assert np.allclose(coordinates[0:5], timestep_coords)
+    check_iterator_coordinates_time_and_box(
+        iterator,
+        20.,
+        timestep_coords,
+        (62, 3),
+        timestep_box
+    )
 
-    assert box.shape == (3, 3)
-    timestep_box = np.array([[2., 0., 0.],
-                             [0., 2., 0.],
-                             [0., 0., 2.]])
-    assert np.allclose(box, timestep_box)
-
-    _, time, coordinates, box = next(iterator)
-    assert puw.get_value(time) == 30.
-    assert coordinates.shape == (62, 3)
-    # We only test coordinates of first five atoms for simplicity
     timestep_coords = np.array([[1.6990486, 1.0393645, 0.43421224, ],
                                 [1.6204891, 0.98685825, 0.37987524],
                                 [1.6354617, 0.88034177, 0.36223724],
                                 [1.6188515, 1.0372851, 0.28325504],
                                 [1.4931669, 0.99599355, 0.46171018]])
-    assert np.allclose(coordinates[0:5], timestep_coords)
+    check_iterator_coordinates_time_and_box(
+        iterator,
+        30.,
+        timestep_coords,
+        (62, 3),
+        timestep_box
+    )
 
-    # Check that the iterator finishes after the 4998 iterations
+    # Check that the iterator finishes after the 4998 remaining iterations
     current_frame = 2
     current_time = 30.
     for _, time, coordinates, box in iterator:
@@ -136,7 +151,7 @@ def test_iterator_with_h5_file():
         current_time += 10
         assert puw.get_value(time) == current_time
         assert coordinates.shape == (62, 3)
-        assert box.shape(3, 3)
+        assert box.shape == (3, 3)
 
     assert current_frame == 4999
     assert current_time == 50000.0

--- a/molsysmt/tests/structure/iterator/test_iterator.py
+++ b/molsysmt/tests/structure/iterator/test_iterator.py
@@ -1,0 +1,100 @@
+import numpy as np
+
+import molsysmt as msm
+
+
+def test_iterator_with_h5_file():
+    pentalanine_file = msm.demo["pentalanine"]["traj.h5"]
+
+    iterator = msm.structure.Iterator(pentalanine_file)
+    assert iterator.n_atoms == 62
+    assert iterator.n_frames == 5000
+
+    frame, time, coordinates, box = next(iterator)
+    assert frame == 0
+    assert time == 10.
+    assert coordinates.shape == (62, 3)
+    # We only test coordinates of first five atoms for simplicity
+    timestep_coords = np.array([[0.7249491, 0.28118464, -0.06514733],
+                                [0.8183724, 0.33541468, -0.07971666],
+                                [0.82463497, 0.38432965, -0.17692305],
+                                [0.88794595, 0.25160828, -0.08384151],
+                                [0.8513755, 0.42293516, 0.03777996]])
+    assert np.allclose(coordinates[0:5], timestep_coords)
+
+    assert box.shape == (3, 3)
+    timestep_box = np.array([[2., 0., 0.],
+                             [0., 2., 0.],
+                             [0., 0., 2.]])
+    assert np.allclose(box, timestep_box)
+
+    frame, time, coordinates, box = next(iterator)
+    assert frame == 1
+    assert time == 20.
+    assert coordinates.shape == (62, 3)
+    # We only test coordinates of first five atoms for simplicity
+    timestep_coords = np.array([[0.49193183, 0.3567681, 0.28309438],
+                                [0.49901953, 0.46519688, 0.2916948],
+                                [0.58446306, 0.4869771, 0.35577384],
+                                [0.41150057, 0.51321983, 0.33545825],
+                                [0.5144549, 0.5183858, 0.15133896]])
+    assert np.allclose(coordinates[0:5], timestep_coords)
+
+    assert box.shape == (3, 3)
+    timestep_box = np.array([[2., 0., 0.],
+                             [0., 2., 0.],
+                             [0., 0., 2.]])
+    assert np.allclose(box, timestep_box)
+
+    frame, time, coordinates, box = next(iterator)
+    assert frame == 2
+    assert time == 30.
+    assert coordinates.shape == (62, 3)
+    # We only test coordinates of first five atoms for simplicity
+    timestep_coords = np.array([[1.6990486, 1.0393645, 0.43421224, ],
+                                [1.6204891, 0.98685825, 0.37987524],
+                                [1.6354617, 0.88034177, 0.36223724],
+                                [1.6188515, 1.0372851, 0.28325504],
+                                [1.4931669, 0.99599355, 0.46171018]])
+    assert np.allclose(coordinates[0:5], timestep_coords)
+
+    # Check that the iterator finishes after the 4998 iterations
+    current_frame = 2
+    current_time = 30.
+    for frame, time, coordinates, box in iterator:
+        current_frame += 1
+        current_time += 10
+        assert frame == current_frame
+        assert time == current_time
+        assert coordinates.shape == (62, 3)
+        assert box.shape(3, 3)
+
+    assert current_frame == 4999
+    assert current_time == 50000.0
+
+
+def test_iterator_with_gromacs_file():
+    traj_file = msm.demo['nglview']['md_1u19.gro']
+    topology_file = msm.demo['nglview']['md_1u19.gro']
+
+    iterator = msm.structure.Iterator([traj_file, topology_file])
+    assert iterator.n_atoms == 5547
+    assert iterator.n_frames == 51
+
+    current_frame = 0
+    current_time = 0
+
+    for frame, time, coordinates, box in iterator:
+        assert frame == current_frame
+        assert time == current_time
+        assert coordinates.shape == (5547, 3)
+        assert box.shape(3, 3)
+        current_frame += 1
+        current_time += 20
+
+    assert current_frame == 50
+    assert current_time == 1000.0
+    final_box = np.array([[7.988997, 0., 0.],
+                          [0., 7.988997, 0.],
+                          [0., 0., 9.910033]])
+    assert np.allclose(box, final_box)

--- a/molsysmt/tests/structure/iterator/test_iterator.py
+++ b/molsysmt/tests/structure/iterator/test_iterator.py
@@ -1,7 +1,8 @@
-import numpy as np
 import molsysmt as msm
 from molsysmt import puw
 import molsysmt._private.exceptions.value_errors as exc
+import mdtraj as mdt
+import numpy as np
 import pytest
 
 
@@ -157,14 +158,16 @@ def test_iterator_with_h5_file():
     assert current_time == 50000.0
 
 
-@pytest.mark.skip
-def test_iterator_with_gromacs_file():
-    traj_file = msm.demo['nglview']['md_1u19.gro']
-    topology_file = msm.demo['nglview']['md_1u19.pdb']
+@pytest.mark.skip(reason="Still not implemented")
+def test_iterator_with_mdtraj():
+    topology_file = msm.demo['nglview']['md_1u19.gro']
+    traj_file = msm.demo['nglview']['md_1u19.xtc']
 
-    iterator = msm.structure.Iterator([traj_file, topology_file])
-    assert iterator.molecular_system.n_atoms == 5547
-    assert iterator.molecular_system.n_structures == 51
+    traj = mdt.load(traj_file, top=topology_file)
+
+    iterator = msm.structure.Iterator(traj)
+    assert iterator._n_atoms == 5547
+    assert iterator._n_structures == 51
 
     current_frame = 0
     current_time = 0

--- a/molsysmt/tests/structure/iterator/test_iterator.py
+++ b/molsysmt/tests/structure/iterator/test_iterator.py
@@ -158,7 +158,6 @@ def test_iterator_with_h5_file():
     assert current_time == 50000.0
 
 
-@pytest.mark.skip(reason="Still not implemented")
 def test_iterator_with_mdtraj():
     topology_file = msm.demo['nglview']['md_1u19.gro']
     traj_file = msm.demo['nglview']['md_1u19.xtc']

--- a/molsysmt/tests/structure/iterator/test_iterator.py
+++ b/molsysmt/tests/structure/iterator/test_iterator.py
@@ -1,7 +1,9 @@
 import numpy as np
 import molsysmt as msm
+import pytest
 
 
+@pytest.mark.skip
 def test_iterator_with_h5_file():
     pentalanine_file = msm.demo["pentalanine"]["traj.h5"]
 
@@ -72,6 +74,7 @@ def test_iterator_with_h5_file():
     assert current_time == 50000.0
 
 
+@pytest.mark.skip
 def test_iterator_with_gromacs_file():
     traj_file = msm.demo['nglview']['md_1u19.gro']
     topology_file = msm.demo['nglview']['md_1u19.pdb']


### PR DESCRIPTION
## Description
A new class to iterate trough trajectories has been implemented in the module `structure` as mentioned in #76. 
Sample usage:

```python
import molsysmt as msm

iterator = msm.structure.Iterator(msm.demo["pentalanine"]["traj.h5"])
for step, time, coordinates, box in iterator:
  print(step, time coordinates, box)

```

Iterator supports all of the optional arguments mentioned in #76.

As a side note, the `native.Structures` class was modified to support the iterator as well as fixing some bugs.